### PR TITLE
Use map location icon for property editor

### DIFF
--- a/Bergmania.OpenStreetMap/Constants.cs
+++ b/Bergmania.OpenStreetMap/Constants.cs
@@ -3,7 +3,9 @@
     public static class Constants
     {
         public const string EditorAlias = "Bergmania.OpenStreetMap";
+        public const string EditorName = "Open Street Map";
         public const string EditorView = "~/App_Plugins/Bergmania.OpenStreetMap/bergmania.openstreetmap.html";
+        public const string EditorIcon = "icon-map-location";
         public const string TextStringView = "textstring";
     }
 }

--- a/Bergmania.OpenStreetMap/OpenStreetMapPropertyEditor.cs
+++ b/Bergmania.OpenStreetMap/OpenStreetMapPropertyEditor.cs
@@ -1,22 +1,19 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using Umbraco.Cms.Core.IO;
+﻿using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.PropertyEditors;
-using Umbraco.Cms.Core.Services;
 
 namespace Bergmania.OpenStreetMap
 {
-    
+
     /// <summary>
     /// Represents a decimal property and parameter editor.
     /// </summary>
     [DataEditor(
         Constants.EditorAlias,
         EditorType.PropertyValue | EditorType.MacroParameter,
-        "Open Street Map",
+        Constants.EditorName,
         Constants.EditorView,
+        Icon = Constants.EditorIcon,
         ValueType = ValueTypes.Json)]
     public class OpenStreetMapPropertyEditor : DataEditor
     {


### PR DESCRIPTION
Instead of the generic icon for property editors and macro parameter editors, we can specify a more unique icon.

I considered using a nested static class, but in that case it should probably keep to obsolete the original constant if developers was using these. 

```
public static class Constants
{
     public static class Editor
     {
         public const string Alias = "Bergmania.OpenStreetMap";
         public const string Icon = "icon-map-location";
         public const string Name = "Open Street Map";
         public const string View = "~/App_Plugins/Bergmania.OpenStreetMap/bergmania.openstreetmap.html";
     }
}
```