### PR TITLE
Return null if value is null or whitespace

### DIFF
--- a/Bergmania.OpenStreetMap/OpenStreetMapPropertyValueConverter.cs
+++ b/Bergmania.OpenStreetMap/OpenStreetMapPropertyValueConverter.cs
@@ -22,14 +22,12 @@ namespace Bergmania.OpenStreetMap
         
         public override object ConvertIntermediateToObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object inter, bool preview)
         {
-            if (inter != null)
-            {
-                var model = _jsonSerializer.Deserialize<OpenStreetMapModel>(inter.ToString());
+            if (inter == null || string.IsNullOrWhiteSpace(inter.ToString()))
+                return null;
 
-                return model;
-            }
+            var model = _jsonSerializer.Deserialize<OpenStreetMapModel>(inter.ToString());
 
-            return null;
+            return model;
         }
     }
 }


### PR DESCRIPTION
If value is null, empty and whitespace we don't need the deserialize the JSON.
E.g. if you switching property editor on an existing datatype.