### PR TITLE
Added setting to data type to enable/disable scroll wheel zoom

### DIFF
--- a/Bergmania.OpenStreetMap.Core/OpenStreetMapConfiguration.cs
+++ b/Bergmania.OpenStreetMap.Core/OpenStreetMapConfiguration.cs
@@ -22,6 +22,10 @@ namespace Bergmania.OpenStreetMap.Core
         [ConfigurationField("allowClear", "Allow Clear", Constants.BooleanView, Description = "Allow clearing previous marker.")]
         public bool AllowClear { get; set; } = true;
 
+        [DataMember(Name = "scrollWheelZoom")]
+        [ConfigurationField("scrollWheelZoom", "Scroll wheel zoom", Constants.BooleanView, Description = "Enable scroll wheel zoom in property editor?")]
+        public bool ScrollWheelZoom { get; set; } = true;
+
         [DataMember(Name ="tileLayer")]
         [ConfigurationField("tileLayer", "Tile Layer", Constants.TextStringView)]
         public string TileLayer { get; set; } = "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png";

--- a/Bergmania.OpenStreetMap.StaticAssets/wwwroot/App_Plugins/Bergmania.OpenStreetMap/bergmania.openstreetmap.controller.js
+++ b/Bergmania.OpenStreetMap.StaticAssets/wwwroot/App_Plugins/Bergmania.OpenStreetMap/bergmania.openstreetmap.controller.js
@@ -6,9 +6,10 @@
         vm.inputId = "osm_search_" + String.CreateGuid();
 
         vm.currentMarker = null;
-        vm.showSearch = $scope.model.config.showSearch ? Object.toBoolean($scope.model.config.showSearch) : false;
-        vm.showCoordinates = $scope.model.config.showCoordinates ? Object.toBoolean($scope.model.config.showCoordinates) : false;
-        vm.allowClear = $scope.model.config.allowClear ? Object.toBoolean($scope.model.config.allowClear) : true;
+        vm.showSearch = $scope.model.config.showSearch != null ? Object.toBoolean($scope.model.config.showSearch) : false;
+        vm.showCoordinates = $scope.model.config.showCoordinates != null ? Object.toBoolean($scope.model.config.showCoordinates) : false;
+        vm.allowClear = $scope.model.config.allowClear != null ? Object.toBoolean($scope.model.config.allowClear) : true;
+        vm.scrollWheelZoom = $scope.model.config.scrollWheelZoom != null ? Object.toBoolean($scope.model.config.scrollWheelZoom) : true;
 
         vm.clearMarker = clearMarker;
 
@@ -18,7 +19,7 @@
             const tileLayer = $scope.model.config.tileLayer || 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
             const tileLayerOptions = { attribution: $scope.model.config.tileLayerAttribution };
 
-            vm.map = L.map($element.find("[data-openstreetmap]")[0])
+            vm.map = L.map($element.find("[data-openstreetmap]")[0], { scrollWheelZoom: vm.scrollWheelZoom })
                 .fitBounds(L.latLngBounds(L.latLng(initValue.boundingBox.southWestCorner.latitude, initValue.boundingBox.southWestCorner.longitude),
                     L.latLng(initValue.boundingBox.northEastCorner.latitude, initValue.boundingBox.northEastCorner.longitude)));
 


### PR DESCRIPTION
Here's an update to resolve issue #20. I've also fixed an issue where the `allowClear` setting was set to `true` in the controller when it was set to `false` in the data type settings. Why were you using the following conditional assignments?

```
vm.allowClear = $scope.model.config.allowClear ? Object.toBoolean($scope.model.config.allowClear) : true;
```

This way `vm.allowClear` is always set to `true` when it's set to `false` in the data type settings. Were you using the conditional assignment to check if the `$scope.model.config.[setting]` value was null or undefined? In that case I think you should be using the following code:

```
vm.showSearch = $scope.model.config.showSearch != null ? Object.toBoolean($scope.model.config.showSearch) : false;
vm.showCoordinates = $scope.model.config.showCoordinates != null ? Object.toBoolean($scope.model.config.showCoordinates) : false;
vm.allowClear = $scope.model.config.allowClear != null ? Object.toBoolean($scope.model.config.allowClear) : true;
vm.scrollWheelZoom = $scope.model.config.scrollWheelZoom != null ? Object.toBoolean($scope.model.config.scrollWheelZoom) : true;
```

I'm using a loose equality operator `!= null` because that works on both null and undefined values.