### PR TITLE
Add possibilities to set a Marker by coordinates

### DIFF
--- a/Bergmania.OpenStreetMap.Core/OpenStreetMapConfiguration.cs
+++ b/Bergmania.OpenStreetMap.Core/OpenStreetMapConfiguration.cs
@@ -18,6 +18,10 @@ namespace Bergmania.OpenStreetMap.Core
         [ConfigurationField("showCoordinates", "Show Coordinates", Constants.BooleanView, Description = "Show marker coordinates below map.")]
         public bool ShowCoordinates { get; set; } = false;
 
+        [DataMember(Name = "showSetMarkerByCoordinates")]
+        [ConfigurationField("showSetMarkerByCoordinates", "Show Set Marker By Coordinates", Constants.BooleanView, Description = "Set Marker By Coordinates field's above map.")]
+        public bool ShowSetMarkerByCoordinates { get; set; } = false;
+
         [DataMember(Name = "allowClear")]
         [ConfigurationField("allowClear", "Allow Clear", Constants.BooleanView, Description = "Allow clearing previous marker.")]
         public bool AllowClear { get; set; } = true;

--- a/Bergmania.OpenStreetMap.StaticAssets/wwwroot/App_Plugins/Bergmania.OpenStreetMap/bergmania.openstreetmap.controller.js
+++ b/Bergmania.OpenStreetMap.StaticAssets/wwwroot/App_Plugins/Bergmania.OpenStreetMap/bergmania.openstreetmap.controller.js
@@ -143,9 +143,13 @@
 
                     $scope.model.value.marker.latitude = marker.lat;
                     $scope.model.value.marker.longitude = marker.lng;
+                    vm.inputLat = marker.lat;
+                    vm.inputLng = marker.lng;
 
                 } else {
                     $scope.model.value.marker = null;
+                    vm.inputLat = null;
+                    vm.inputLng = null;
                 }
             }, 0);
         }

--- a/Bergmania.OpenStreetMap.StaticAssets/wwwroot/App_Plugins/Bergmania.OpenStreetMap/bergmania.openstreetmap.controller.js
+++ b/Bergmania.OpenStreetMap.StaticAssets/wwwroot/App_Plugins/Bergmania.OpenStreetMap/bergmania.openstreetmap.controller.js
@@ -77,7 +77,7 @@
         }
 
         function setMarker() {
-            if (!vm.inputLat || !vm.inputLng) {
+            if (!Number.isFinite(vm.inputLat) || !Number.isFinite(vm.inputLng)) {
                 return
             }
 

--- a/Bergmania.OpenStreetMap.StaticAssets/wwwroot/App_Plugins/Bergmania.OpenStreetMap/bergmania.openstreetmap.controller.js
+++ b/Bergmania.OpenStreetMap.StaticAssets/wwwroot/App_Plugins/Bergmania.OpenStreetMap/bergmania.openstreetmap.controller.js
@@ -4,13 +4,17 @@
         const vm = this;
 
         vm.inputId = "osm_search_" + String.CreateGuid();
+        vm.inputLatId = "osm_Lat_" + String.CreateGuid();
+        vm.inputLngId = "osm_Lng_" + String.CreateGuid();
 
         vm.currentMarker = null;
         vm.showSearch = $scope.model.config.showSearch != null ? Object.toBoolean($scope.model.config.showSearch) : false;
+        vm.showSetMarkerByCoordinates = $scope.model.config.showSetMarkerByCoordinates != null ? Object.toBoolean($scope.model.config.showSetMarkerByCoordinates) : false;
         vm.showCoordinates = $scope.model.config.showCoordinates != null ? Object.toBoolean($scope.model.config.showCoordinates) : false;
         vm.allowClear = $scope.model.config.allowClear != null ? Object.toBoolean($scope.model.config.allowClear) : true;
         vm.scrollWheelZoom = $scope.model.config.scrollWheelZoom != null ? Object.toBoolean($scope.model.config.scrollWheelZoom) : true;
 
+        vm.setMarker = setMarker;
         vm.clearMarker = clearMarker;
 
         function onInit() {
@@ -38,6 +42,11 @@
 
             if (initValue.marker) {
                 vm.currentMarker = L.marker(L.latLng(initValue.marker.latitude, initValue.marker.longitude), { draggable: true }).addTo(vm.map);
+
+                if (vm.showSetMarkerByCoordinates) {
+                    vm.inputLat = initValue.marker.latitude
+                    vm.inputLng = initValue.marker.longitude
+                }
             }
 
             if (vm.currentMarker) {
@@ -65,6 +74,25 @@
             }
 
 
+        }
+
+        function setMarker() {
+            if (!vm.inputLat || !vm.inputLng) {
+                return
+            }
+
+            clearMarker();
+
+            const latlng = [vm.inputLat, vm.inputLng]
+
+            vm.map.setView(latlng);
+            vm.currentMarker = L.marker(latlng, { draggable: true }).addTo(vm.map);
+
+            if (vm.currentMarker) {
+                vm.currentMarker.on('dragend', updateModel);
+            }
+
+            updateModel();
         }
 
         function onMapClick(e) {

--- a/Bergmania.OpenStreetMap.StaticAssets/wwwroot/App_Plugins/Bergmania.OpenStreetMap/bergmania.openstreetmap.html
+++ b/Bergmania.OpenStreetMap.StaticAssets/wwwroot/App_Plugins/Bergmania.OpenStreetMap/bergmania.openstreetmap.html
@@ -10,6 +10,23 @@
         </umb-search-filter>
     </div>
 
+    <div ng-if="vm.showSetMarkerByCoordinates" class="flex items-center mb3">
+        <localize key="bergmania_latitude">Latitude</localize>:
+        <input type="number"
+               ng-model="vm.inputLat"
+               id="{{vm.inputLatId}}"
+               ng-change="vm.setMarker()"
+               placeholder="Latitude"
+               class="ml2" />
+        <localize key="bergmania_longitude" class="ml3">Longitude</localize>:
+        <input type="number"
+               ng-model="vm.inputLng"
+               id="{{vm.inputLngId}}"
+               ng-change="vm.setMarker()"
+               placeholder="Longitude"
+               class="ml2" />
+    </div>
+
     <div data-openstreetmap="true" style="width: 100%; height: 400px;"></div>
 
     <div class="flex items-center mt2" ng-if="vm.showCoordinates || vm.allowClear">


### PR DESCRIPTION
Currently, there is no way to find or set a specific place by coordinates. 
I think in some cases it can be very useful.
So I add the possibility of setting a Marker by pasting coordinates to latitude and longitude fields.
To enable this feature need enable the `showSetMarkerByCoordinates` option from the data type settings

![image](https://user-images.githubusercontent.com/85081556/212763744-e0330ea0-16ba-4a9c-9682-e2636473e319.png)

![record_230116_231029](https://user-images.githubusercontent.com/85081556/212766243-05dd6030-380a-453b-a1fc-71b86442bcb1.gif)